### PR TITLE
Previously had calls to CFPropertyListCreateWithXMLData(.) and CFProp…

### DIFF
--- a/darwinxref/cfutils.c
+++ b/darwinxref/cfutils.c
@@ -87,12 +87,14 @@ CFPropertyListRef read_plist(char* path) {
                         if (buffer != (void*)-1) {
                                 CFDataRef data = CFDataCreateWithBytesNoCopy(NULL, buffer, size, kCFAllocatorNull);
                                 if (data) {
-                                        CFStringRef str = NULL;
-                                        result = CFPropertyListCreateFromXMLData(NULL, data, kCFPropertyListMutableContainers, &str);
+                                        CFErrorRef err;
+                                        result = CFPropertyListCreateWithData(NULL, data, kCFPropertyListMutableContainers, kCFPropertyListXMLFormat_v1_0, &err);
                                         CFRelease(data);
                                         if (result == NULL) {
+                                                CFStringRef str = CFErrorCopyDescription(err);
                                                 perror_cfstr(str);
                                         }
+                                        CFRelease(err);
                                 }
                                 munmap(buffer, size);
                         } else {

--- a/darwinxref/plugins/exportProject.c
+++ b/darwinxref/plugins/exportProject.c
@@ -83,7 +83,11 @@ static int run(CFArrayRef argv) {
 
 	CFPropertyListRef plist = preplist;
 	if (xml) {
-		CFDataRef data = CFPropertyListCreateXMLData(NULL, plist);
+    // TODO: Currently, this doesn't handle errors. The last parameter should be a CFErrorRef
+    // object, and we should pring error status if the data object is NULL. I'm not currently
+    // making this change as I'm only fixing the perviously deprecated method call by
+    // replacing with CFPropertyListCreateData(.).
+    CFDataRef data = CFPropertyListCreateData(NULL, plist, kCFPropertyListXMLFormat_v1_0, 0, NULL);
 		res = write(STDOUT_FILENO, CFDataGetBytePtr(data), (ssize_t)CFDataGetLength(data));
 	} else {
 		res = writePlist(stdout, plist, 0);


### PR DESCRIPTION
By submitting a request, you represent that you have the right to license
your contribution to the community, and agree that your contributions are
licensed under the [BSD License accompanying darwinbuild](LICENSE.txt).

For existing files modified by your request, you represent that you have
retained any existing copyright notices and licensing terms. For each new
file in your request, you represent that you have added to the file a
copyright notice (including the year and the copyright owner's name) and
darwinbuild's licensing terms.

…ertyListCreateXMLData(.); replaced with calls to non-deprecated CFPropertyListCreateWithData(.) and CFPropertyListCreateData(.) calls in darwinxref/xfutils.c:~90 and darwinxref/plugins/exportProject.c:~87
