### PR TITLE
Change binary site

### DIFF
--- a/plists/10A432.plist
+++ b/plists/10A432.plist
@@ -1,7 +1,7 @@
 // !$*UTF8*$!
 {
 	binary_sites = (
-		"http://src.macosforge.org/Roots/10A432/",
+		"http://src.macosforge.org/Roots/10A432",
 	);
 	build = 10A432;
 	darwin = "Darwin 10.0";


### PR DESCRIPTION
Changed the binary site from "http://src.macosforge.org/Roots/10A432/" to "http://src.macosforge.org/Roots/10A432". When installing roots on newer versions of macOS Darwinbuild will be unable to download any of the root packages from the repository when a strike is present at the end of the URL. This causes the binary site link in xref.db to go from "http://src.macosforge.org/Roots/10A432/files.root.tar.gz" to "http://src.macosforge.org/Roots/10A432//files.root.tar.gz" (A non-existent URL that results in 404, and subsequent build failure.)

By submitting a request, you represent that you have the right to license
your contribution to the community, and agree that your contributions are
licensed under the [BSD License accompanying darwinbuild](LICENSE.txt).

For existing files modified by your request, you represent that you have
retained any existing copyright notices and licensing terms. For each new
file in your request, you represent that you have added to the file a
copyright notice (including the year and the copyright owner's name) and
darwinbuild's licensing terms.
